### PR TITLE
Stop stacking dropped items

### DIFF
--- a/item.inc
+++ b/item.inc
@@ -950,8 +950,8 @@ timer DropItemDelay[400](playerid) {
 
     CreateItemInWorld(
         id,
-        RandomFloat(x - 0.5, x + 0.5) + (0.5 * floatsin(-r, degrees)),
-        RandomFloat(y - 0.5, x + 0.5) + (0.5 * floatcos(-r, degrees)),
+        (x + RandomFloat(-0.5, 0.5)) + (0.5 * floatsin(-r, degrees)),
+        (y + RandomFloat(-0.5, 0.5)) + (0.5 * floatcos(-r, degrees)),
         z - ITEM_FLOOR_OFFSET,
         0.0,
         0.0,


### PR DESCRIPTION
When we drop an item, it should appear in a random position in front of us. In the previous releases it's been a static position, meaning if we dropped multiple items, they would appear in each other and it was impossible to tell there are multiple items on the ground.

It appears while migrating to open.mp I accidentally committed my scratch code which was calculating the value incorrectly (way too high offset).